### PR TITLE
[SPRINT- M25] Fix: Added the Back Navigation and Panel Collapse UI

### DIFF
--- a/src/pages/questions/[id].tsx
+++ b/src/pages/questions/[id].tsx
@@ -18,9 +18,8 @@ const QuestionBar = () => {
     test_case?: string;
     answer?: string;
     constraints?: string;
-   
   };
-  
+
   const [ques, setQues] = useState<Problem | null>(null);
   const [loading, setLoading] = useState(true);
   const [leftPanelCollapsed, setLeftPanelCollapsed] = useState(false);
@@ -53,19 +52,39 @@ const QuestionBar = () => {
 
   return (
     <div className={styles.container}>
+      {/* NEW: Dedicated button to expand the panel when it's collapsed */}
+      {leftPanelCollapsed && (
+        <button
+          className={styles.expandBtn}
+          onClick={toggleLeftPanel}
+          aria-label="Expand problem panel"
+        >
+          →
+        </button>
+      )}
+
       {/* Left Panel - Problem Description */}
       <div className={`${styles.leftPane} ${leftPanelCollapsed ? styles.collapsed : ''}`}>
         <div className={styles.panelHeader}>
+          {/* NEW: Back button to navigate to /contests */}
+          <button
+            className={styles.backBtn}
+            onClick={() => router.push('/contests')}
+            aria-label="Back to contests"
+          >
+            &larr; Back
+          </button>
           <h3 className={styles.panelTitle}>Problem</h3>
-          <button 
+          <button
             className={styles.collapseBtn}
             onClick={toggleLeftPanel}
             aria-label="Toggle problem panel"
           >
-            {leftPanelCollapsed ? '→' : '←'}
+            {/* This button will now only handle collapsing */}
+            ←
           </button>
         </div>
-        
+
         {!leftPanelCollapsed && (
           <div className={styles.problemContent}>
             {loading ? (
@@ -121,7 +140,7 @@ const QuestionBar = () => {
             ) : (
               <div className={styles.errorContainer}>
                 <p className={styles.error}>Problem not found</p>
-                <button 
+                <button
                   className={styles.retryBtn}
                   onClick={() => router.reload()}
                 >
@@ -136,8 +155,8 @@ const QuestionBar = () => {
       {/* Right Panel - Code Editor */}
       <div className={`${styles.rightPane} ${leftPanelCollapsed ? styles.expanded : ''}`}>
         <div className={styles.editorContainer}>
-          <CodeEditor 
-            id={typeof id === 'string' ? id : ''} 
+          <CodeEditor
+            id={typeof id === 'string' ? id : ''}
           />
         </div>
       </div>

--- a/src/styles/CodeEditor.module.css
+++ b/src/styles/CodeEditor.module.css
@@ -406,7 +406,59 @@
   overflow-y: auto;
 }
 
+/* Add these to your CodeEditor.module.css file */
 
+/* Style for the new Back button */
+.backBtn {
+  background: none;
+  border: 1px solid #ccc;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-right: auto; /* Pushes other items to the right */
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.backBtn:hover {
+  background-color: #444;
+  border-color: #888;
+}
+
+/* Style for the panel header to accommodate the new button */
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between; /* This might need adjustment */
+  gap: 1rem; /* Adds space between header items */
+  padding: 10px 15px;
+  border-bottom: 1px solid #333;
+}
+
+/* Style for the dedicated Expand button */
+.expandBtn {
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  z-index: 100;
+  background-color: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.expandBtn:hover {
+  background-color: #444;
+}
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
# Fixes: Back Navigation and Panel Collapse UI

**Closes Issues:** #36, #37

## 📝 Description

This pull request addresses two user interface (UI) bugs in the code editor environment, improving navigation and usability.

1.  **Bug #36: Missing Back Navigation:** Users had no clear way to exit the question IDE page and return to the main contest list.
2.  **Bug #37: Unrecoverable Panel Collapse:** When the problem description panel was collapsed, the toggle button would disappear along with it, preventing the user from ever re-expanding it.

---

## Reviewers

-   @amaydixit11

---

## ✅ Changes Implemented

###  Bug Fix #36: Added a Back Button

-   A **"← Back" button** has been added to the header of the problem description panel.
-   This button utilizes Next.js's `useRouter` hook to programmatically navigate the user back to the `/contests` route, providing a clear and expected exit path from the IDE.

```jsx
// src/components/QuestionBar.js
<button
    className={styles.backBtn}
    onClick={() => router.push('/contests')}
    aria-label="Back to contests"
>
    &larr; Back
</button>