### PR TITLE
[SPRINT- M25] feat:  Adding leaderboard pro banner

### DIFF
--- a/src/pages/questions/[id].tsx
+++ b/src/pages/questions/[id].tsx
@@ -18,9 +18,8 @@ const QuestionBar = () => {
     test_case?: string;
     answer?: string;
     constraints?: string;
-   
   };
-  
+
   const [ques, setQues] = useState<Problem | null>(null);
   const [loading, setLoading] = useState(true);
   const [leftPanelCollapsed, setLeftPanelCollapsed] = useState(false);
@@ -53,19 +52,39 @@ const QuestionBar = () => {
 
   return (
     <div className={styles.container}>
+      {/* NEW: Dedicated button to expand the panel when it's collapsed */}
+      {leftPanelCollapsed && (
+        <button
+          className={styles.expandBtn}
+          onClick={toggleLeftPanel}
+          aria-label="Expand problem panel"
+        >
+          →
+        </button>
+      )}
+
       {/* Left Panel - Problem Description */}
       <div className={`${styles.leftPane} ${leftPanelCollapsed ? styles.collapsed : ''}`}>
         <div className={styles.panelHeader}>
+          {/* NEW: Back button to navigate to /contests */}
+          <button
+            className={styles.backBtn}
+            onClick={() => router.push('/contests')}
+            aria-label="Back to contests"
+          >
+            &larr; Back
+          </button>
           <h3 className={styles.panelTitle}>Problem</h3>
-          <button 
+          <button
             className={styles.collapseBtn}
             onClick={toggleLeftPanel}
             aria-label="Toggle problem panel"
           >
-            {leftPanelCollapsed ? '→' : '←'}
+            {/* This button will now only handle collapsing */}
+            ←
           </button>
         </div>
-        
+
         {!leftPanelCollapsed && (
           <div className={styles.problemContent}>
             {loading ? (
@@ -121,7 +140,7 @@ const QuestionBar = () => {
             ) : (
               <div className={styles.errorContainer}>
                 <p className={styles.error}>Problem not found</p>
-                <button 
+                <button
                   className={styles.retryBtn}
                   onClick={() => router.reload()}
                 >
@@ -136,8 +155,8 @@ const QuestionBar = () => {
       {/* Right Panel - Code Editor */}
       <div className={`${styles.rightPane} ${leftPanelCollapsed ? styles.expanded : ''}`}>
         <div className={styles.editorContainer}>
-          <CodeEditor 
-            id={typeof id === 'string' ? id : ''} 
+          <CodeEditor
+            id={typeof id === 'string' ? id : ''}
           />
         </div>
       </div>

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -565,6 +565,22 @@ export default function StatsComparison() {
     </div>
   </div>
 </div>
+
+ <div className={styles.promoBanner}>
+            <p className={styles.promoText}>
+                🚀 Get more stats, comparisons and a leaderboard at <strong>leaderboard-pro</strong>
+            </p>
+            <a
+                href="https://leaderboardpro.vercel.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.promoButton}
+            >
+                Explore Pro
+            </a>
+        </div>
+
+        
         <div className={styles.dashboardGrid}>
           <RatingTrendChart />
           <ContestGainChart />

--- a/src/styles/CodeEditor.module.css
+++ b/src/styles/CodeEditor.module.css
@@ -406,7 +406,59 @@
   overflow-y: auto;
 }
 
+/* Add these to your CodeEditor.module.css file */
 
+/* Style for the new Back button */
+.backBtn {
+  background: none;
+  border: 1px solid #ccc;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-right: auto; /* Pushes other items to the right */
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.backBtn:hover {
+  background-color: #444;
+  border-color: #888;
+}
+
+/* Style for the panel header to accommodate the new button */
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between; /* This might need adjustment */
+  gap: 1rem; /* Adds space between header items */
+  padding: 10px 15px;
+  border-bottom: 1px solid #333;
+}
+
+/* Style for the dedicated Expand button */
+.expandBtn {
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  z-index: 100;
+  background-color: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.expandBtn:hover {
+  background-color: #444;
+}
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/stats.module.css
+++ b/src/styles/stats.module.css
@@ -657,3 +657,62 @@
 }
 
 /* ... keep the rest of your original CSS for controls and other elements ... */
+/* ==========================================================================
+   Promo Banner Styles (Theme-Aligned)
+   ========================================================================== */
+
+.promoBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background-color: #eef2ff; /* A light, complementary blue-gray */
+  border: 1px solid #dbeafe; /* A soft blue border */
+  color: #374151; /* Dark gray text for readability */
+  padding: 1rem 1.5rem;
+  border-radius: 12px; /* Matches the rounded corners of your cards */
+  margin-bottom: 2.5rem;
+  animation: fadeInUp 0.3s ease forwards;
+}
+
+.promoText {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.promoText strong {
+  color: #3b82f6; /* Uses your primary blue accent color */
+  font-weight: 600;
+}
+
+.promoButton {
+  background-color: #3b82f6; /* Your primary blue button color */
+  color: #ffffff;
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px; /* Matches button styles */
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  border: none;
+  box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.2), 0 2px 4px -2px rgba(59, 130, 246, 0.1);
+  transition: all 0.2s ease-in-out;
+}
+
+.promoButton:hover {
+  background-color: #2563eb; /* A slightly darker blue for hover */
+  transform: translateY(-2px);
+  box-shadow: 0 7px 14px -3px rgba(59, 130, 246, 0.3), 0 4px 6px -4px rgba(59, 130, 246, 0.2);
+}
+
+/* Responsive adjustments for the banner */
+@media (max-width: 768px) {
+  .promoBanner {
+    flex-direction: column;
+    text-align: center;
+    gap: 1rem;
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
# Feature: Add Promotional Banner for Leaderboard Pro

**Closes:** #42

## 📝 Description

This pull request introduces a new promotional banner on the Performance Analytics (`/stats`) page. The goal of this feature is to inform users about the advanced features available on our companion site, **Leaderboard Pro**, and provide a direct link to it.

To maintain a cohesive user experience, the banner has been carefully styled to align with the existing application's light theme, using the established color palette and component design.

---

Reviewer:
@amaydixit11 

## ✅ Changes Implemented

### 1. Banner Component Added

A new React component has been added to the `StatsComparison` page. It is placed between the header and the main dashboard grid.

<img width="1526" height="874" alt="Screenshot 2025-08-25 142454" src="https://github.com/user-attachments/assets/bfeb9925-aa1d-448a-aaf5-f3a77cbcec30" />
