### PR TITLE
Fix: Quiz fullscreen mode not working properly (#109)

### DIFF
--- a/src/components/quiz/QuestionDisplay.tsx
+++ b/src/components/quiz/QuestionDisplay.tsx
@@ -21,7 +21,6 @@ const QuestionDisplay: React.FC<Props> = ({ question, userAnswer, questionNumber
   const handleNext = useCallback(() => {
     if (questionNumber === totalQuestions) {
       dispatch({ type: 'FINISH_QUIZ' });
-      document.exitFullscreen().catch(err => console.log(err.message));
     } else {
       dispatch({ type: 'NEXT_QUESTION' });
     }

--- a/src/components/quiz/StartScreen.tsx
+++ b/src/components/quiz/StartScreen.tsx
@@ -40,7 +40,6 @@ const StartScreen: React.FC<Props> = ({ onStart }) => {
 
   const handleStartSolo = () => {
     onStart(selectedTopic, selectedDifficulty, totalQuestions);
-    document.documentElement.requestFullscreen().catch(err => console.log(err.message));
   };
 
   const handleCreatePrivateBattle = async () => {
@@ -65,7 +64,6 @@ const StartScreen: React.FC<Props> = ({ onStart }) => {
     socket.emit('join_random_queue', user.uid);
 
     socket.on('match_found', (roomId: string) => {
-      document.documentElement.requestFullscreen().catch(err => console.log(err.message));
       router.push(`/quiz/battle/${roomId}`);
     });
   };

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -78,17 +78,20 @@ const QuizPage: React.FC = () => {
   }, [status, user, questions, userAnswers, score, totalQuestions]);
 
   return (
-    <div className={styles['quiz-page-wrapper']}>
+    <div className={`${styles['quiz-page-wrapper']} ${status === 'active' ? styles['fullscreen-mode'] : ''}`}>
       {/* 👇 This is the header section, now restored to the main page layout 👇 */}
-      <div className={styles["header-section"]}>
-        <div className={styles["header-text"]}>
-          <h1 className={styles["main-title"]}> 🧠 Quiz Yourself</h1>
-          <p className={styles["subtitle"]}>Test your knowledge with an AI-generated quiz</p>
+      {/* Hide header when quiz is active to provide distraction-free environment */}
+      {status !== 'active' && (
+        <div className={styles["header-section"]}>
+          <div className={styles["header-text"]}>
+            <h1 className={styles["main-title"]}> 🧠 Quiz Yourself</h1>
+            <p className={styles["subtitle"]}>Test your knowledge with an AI-generated quiz</p>
+          </div>
+          <div className={styles["header-image"]}>
+            <img src="/images/study.png" alt="Study illustration" className={styles["practice-image"]} />
+          </div>
         </div>
-        <div className={styles["header-image"]}>
-          <img src="/images/study.png" alt="Study illustration" className={styles["practice-image"]} />
-        </div>
-      </div>
+      )}
 
       {/* The rest of the page logic correctly renders the right component below the header */}
       {status === 'loading' && <p className={styles.loading}>Generating your quiz...</p>}
@@ -96,13 +99,15 @@ const QuizPage: React.FC = () => {
       {status === 'ready' && <StartScreen onStart={handleStartQuiz} />}
 
       {status === 'active' && questions.length > 0 && (
-        <QuestionDisplay
-          question={questions[index]}
-          userAnswer={userAnswers[index]}
-          questionNumber={index + 1}
-          totalQuestions={questions.length}
-          dispatch={dispatch}
-        />
+        <div className={styles['quiz-fullscreen-container']}>
+          <QuestionDisplay
+            question={questions[index]}
+            userAnswer={userAnswers[index]}
+            questionNumber={index + 1}
+            totalQuestions={questions.length}
+            dispatch={dispatch}
+          />
+        </div>
       )}
 
       {status === 'finished' && (

--- a/src/styles/Quiz.module.css
+++ b/src/styles/Quiz.module.css
@@ -1067,3 +1067,63 @@
     transform: rotate(360deg);
   }
 }
+
+/* ==========================================================================
+   Fullscreen Quiz Mode Styles
+   ========================================================================== */
+
+/* When quiz is active, make the page wrapper fullscreen */
+.quiz-page-wrapper.fullscreen-mode {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #ffffff;
+  z-index: 9999;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+}
+
+/* Container for fullscreen quiz content */
+.quiz-fullscreen-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background-color: #ffffff;
+}
+
+/* Adjust quiz form in fullscreen mode */
+.fullscreen-mode .quiz-form {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+}
+
+/* Responsive adjustments for fullscreen mode */
+@media (max-width: 768px) {
+  .quiz-fullscreen-container {
+    padding: 1rem;
+  }
+  
+  .fullscreen-mode .quiz-form {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .quiz-fullscreen-container {
+    padding: 0.5rem;
+  }
+  
+  .fullscreen-mode .quiz-form {
+    padding: 1rem;
+    border-radius: 12px;
+  }
+}


### PR DESCRIPTION
🐛 Bug Fix
Fixes #109 - Quiz full-screen mode regression where the quiz window appears inside the main page instead of covering the entire screen.

📝 Problem
Previously, clicking "Generate Solo Quiz" would open the quiz in full-screen mode as intended. Recently, this behavior regressed:

The quiz window now appears inside the main page
The page expands incorrectly and takes over the full screen
This disturbs the intended distraction-free quiz environment
Previous full-screen implementation caused overlapping and layout issues
✅ Solution
Replaced browser's native fullscreen API with a CSS-based fullscreen implementation:

Removed problematic fullscreen API calls from 
StartScreen.tsx
 and 
QuestionDisplay.tsx
Implemented CSS-based fullscreen mode that properly covers the viewport
Hide header section when quiz is active for distraction-free experience
Added fullscreen container with proper centering and responsive design
Maintained all functionality - topic/difficulty/question selections persist
🎯 Changes Made
Modified Files:

src/pages/quiz.tsx
 - Added conditional header rendering and fullscreen wrapper
src/components/quiz/StartScreen.tsx
 - Removed requestFullscreen() call
src/components/quiz/QuestionDisplay.tsx
 - Removed exitFullscreen() call
src/styles/Quiz.module.css
 - Added fullscreen mode styles
✨ Acceptance Criteria Met
 Clicking "Generate Solo Quiz" opens the quiz in full-screen mode
 Quiz UI covers content area without unexpected resizing
 All prior functionality (topic/difficulty/number of questions) works correctly
 Compatible across desktop and mobile layouts
 No overlapping or page resizing issues
 Distraction-free quiz environment maintained
🧪 Testing
Please test by:

Navigate to the Quiz section
Select topic, difficulty, and number of questions
Click "Generate Solo Quiz"
Verify quiz displays in fullscreen mode correctly
Complete quiz and verify exit back to normal view