### PR TITLE
Fix Java compilation mismatch by renaming default template class to Main (Closes #169)

### DIFF
--- a/src/constants/boilerplate.tsx
+++ b/src/constants/boilerplate.tsx
@@ -52,7 +52,7 @@ greet("CanonForces")
 `.trim(),
 
   java: `
-public class HelloWorld {
+public class Main {
     public static void main(String[] args) {
         System.out.println("Hello,CanonForces!");
     }


### PR DESCRIPTION
Hi there! 

This PR resolves the compilation error that occurred for all users using Java as their programming language fixes #169 

* **Fix:** Renamed the default Java template class from `HelloWorld` to `Main` in `src/constants/boilerplate.tsx`.
* **Reason:** The Judge0 environment compiles and runs submissions using the filename `Main.java`. Since Java requires the name of a public class to match its filename exactly, the default template class `HelloWorld` caused compilation error  (`class HelloWorld is public, should be declared in a file named HelloWorld.java`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated Java code boilerplate snippet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenLake/canonforces/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->