### PR TITLE
Fixed : Reset Code Button

### DIFF
--- a/src/common/components/CodeEditor/CodeEditor.tsx
+++ b/src/common/components/CodeEditor/CodeEditor.tsx
@@ -38,6 +38,7 @@ type Props = {
   hintLevel?: number;
   isFetchingHint?: boolean;
   onGetHint?: () => void;
+  onResetCode?: () => void;
 };
 
 const CodeEditor = ({
@@ -59,6 +60,7 @@ const CodeEditor = ({
   hintLevel,
   isFetchingHint,
   onGetHint,
+  onResetCode,
 }: Props) => {
   const [isFullscreen, setIsFullscreen] = React.useState(false);
   const [isAiSidebarOpen, setIsAiSidebarOpen] = React.useState(false);
@@ -73,7 +75,9 @@ const CodeEditor = ({
   };
 
   const resetCode = () => {
-    console.log('Reset button clicked - state is in parent.');
+    if (onResetCode) {
+      onResetCode();
+    }
   };
 
   return (

--- a/src/pages/questions/[id].tsx
+++ b/src/pages/questions/[id].tsx
@@ -117,6 +117,11 @@ const QuestionBar = () => {
     setCodeValue(value || '');
   };
 
+  const handleResetCode = () => {
+    setCodeValue(CODE_SNIPPETS[language as keyof typeof CODE_SNIPPETS]);
+    toast.success('Code reset to default')
+  }
+
   const handleRun = async () => {
     if (isRunning) return;
     setIsRunning(true);
@@ -504,6 +509,7 @@ const QuestionBar = () => {
           codeValue={codeValue}
           onLanguageChange={onLanguageChange}
           onCodeChange={onCodeChange}
+          onResetCode={handleResetCode}
           output={output}
           isRunning={isRunning}
           submissionResult={submissionResult}


### PR DESCRIPTION
##  Related Issue
- [x] Fixes #171 

---

## Changes Introduced
- **Fixed:** Reset button in the code editor now correctly restores the editor to the original template code.

---

##  Why This Change?
- **Problem:** The Reset button in the IDE code editor was non-functional  clicking it had no effect, leaving users unable to restore starter code.
- **Solution:** Fixed the Reset button logic so it correctly resets the editor content back to the default template code.
- **Impact:** All users of the code editor can now reliably reset their code to the starter template when needed.

---

## 🖼️ Screenshots / Loom Video (if applicable)
 | 
<img width="1810" height="934" alt="image" src="https://github.com/user-attachments/assets/9d33745a-1160-472f-8111-474985dd0ce4" />

<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/90afea67-cc7c-4608-ab31-b9ab8411aced" />
 |

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added code reset capability to the editor that restores the default code snippet for the currently selected language and displays a success confirmation to the user.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenLake/canonforces/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->